### PR TITLE
Fix improper class name

### DIFF
--- a/lib/client/checkpoints.rb
+++ b/lib/client/checkpoints.rb
@@ -76,7 +76,7 @@ module Checkpoints
           checkpoints: checkpoints
         }
       )
-      convert_response(response, "checkpoints")
+      convert_response(response, "checkpoint")
     end
   end
 end


### PR DESCRIPTION
@bmneely just going to merge this since it's a fix for me being an idiot and not reading the entire `ClassFactory.build_response_object` method.